### PR TITLE
update sample module code and provide property defaults

### DIFF
--- a/meterpreter/extension-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/meterpreter/extension-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -5,6 +5,15 @@
 		name="Java Meterpreter extension archetype">
 	<requiredProperties>
 		<requiredProperty key="pluginName" />
+		<requiredProperty key="groupId">
+			<defaultValue>com.metasploit</defaultValue>
+		</requiredProperty>
+		<requiredProperty key="artifactId">
+			<defaultValue>Metasploit-Java-Meterpreter-${pluginName}</defaultValue>
+		</requiredProperty>
+		<requiredProperty key="package">
+			<defaultValue>com.metasploit.meterpreter.${pluginName}</defaultValue>
+		</requiredProperty>
 	</requiredProperties>
 	<fileSets>
 	<fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/meterpreter/extension-archetype/src/main/resources/archetype-resources/__pluginName__.rb
+++ b/meterpreter/extension-archetype/src/main/resources/archetype-resources/__pluginName__.rb
@@ -1,37 +1,48 @@
+# -*- coding: binary -*-
+
 module Rex
-module Post
-module Meterpreter
-module Extensions
-module ${pluginName.substring(0,1).toUpperCase()}${pluginName.substring(1)}
+  module Post
+    module Meterpreter
+      module Extensions
+        # This module contains a 'Hello World' meterpreter extension
+        module ${pluginName.substring(0,1).toUpperCase()}${pluginName.substring(1)}
+          TLV_TYPE_GREETEE = TLV_META_TYPE_STRING | (TLV_EXTENSIONS + 1)
 
-TLV_TYPE_GREETEE = TLV_META_TYPE_STRING | (TLV_EXTENSIONS + 1);
+          # This module implements a 'Hello World' meterpreter extension
+          class ${pluginName.substring(0,1).toUpperCase()}${pluginName.substring(1)} < Extension
+            def initialize(client)
+              super(client, '${pluginName}')
 
-class ${pluginName.substring(0,1).toUpperCase()}${pluginName.substring(1)} < Extension
+              client.register_extension_aliases(
+                [
+                  {
+                    'name' => '${pluginName}',
+                    'ext'  => self
+                  }
+                ])
+            end
 
-	def initialize(client)
-		super(client, '${pluginName}')
+            # Sends a greet_world request and gets a reply
+            #
+            # @return [String]
+            def ${pluginName}_greet_world
+              request = Packet.create_request('${pluginName}_greet_world')
+              response = client.send_request(request)
+              response.get_tlv_value(TLV_TYPE_STRING)
+            end
 
-		client.register_extension_aliases(
-			[
-				{
-					'name' => '${pluginName}',
-					'ext'  => self
-				}
-			])
-	end
-
-	def ${pluginName}_greet_world()
-		request = Packet.create_request('${pluginName}_greet_world')
-		response = client.send_request(request)
-		return response.get_tlv_value(TLV_TYPE_STRING)
-	end
-
-	def ${pluginName}_greet_someone(greetee)
-		request = Packet.create_request('${pluginName}_greet_someone')
-		request.add_tlv(TLV_TYPE_GREETEE, greetee)
-		response = client.send_request(request)
-		return response.get_tlv_value(TLV_TYPE_STRING)
-	end
+            # Sends a greet_someone request and gets a reply
+            #
+            # @return [String]
+            def ${pluginName}_greet_someone(greetee)
+              request = Packet.create_request('${pluginName}_greet_someone')
+              request.add_tlv(TLV_TYPE_GREETEE, greetee)
+              response = client.send_request(request)
+              response.get_tlv_value(TLV_TYPE_STRING)
+            end
+          end
+        end
+      end
+    end
+  end
 end
-
-end; end; end; end; end


### PR DESCRIPTION
Hi, what do you think of these modifications for rapid7/metasploit-javapayload#5?

This adds some default values to the archetype data, so the prompting suggests some nice defaults based on the pluginName. Also, it makes mostly cosmetic changes to the generated .rb file (tabs->spaces, format specifier, remove semi-colons, minimal YARD comments, etc.) just to set a good example for new code.
